### PR TITLE
make velocity module pub and the xr feature not default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ too_many_arguments = "allow"
 type_complexity = "allow"
 
 [features]
-default = ["xr"]
 xr = ["dep:bevy_mod_openxr", "dep:bevy_mod_xr", "dep:bevy_xr_utils"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod input;
 mod look;
 pub mod movement;
 pub mod player;
-mod velocity;
+pub mod velocity;
 
 pub struct VrControllerPlugin;
 


### PR DESCRIPTION
makes the velocity public since the only component in there is public and that seems to be needed for networked remote players

also make the xr feature not a part of default features since it seems more a feature to enable if needed than disable manually